### PR TITLE
Update LineSeries.rst

### DIFF
--- a/models/series/LineSeries.rst
+++ b/models/series/LineSeries.rst
@@ -35,7 +35,7 @@ property.
 
 - If the ``Mapping`` property is set, each element in the collection
   will be transformed
-- If the collection is a list of ``DataPoint``, it will be used with no
+- If the collection is a list of ``DataPoint``, or a type that implements ``IDataPointProvider``, it will be used with no
   mapping
 - If the ``DataFieldX`` and ``DataFieldY`` properties are set, each
   element of the collection will be reflected to create a data point


### PR DESCRIPTION
Clarify that ItemSource can be set to a collection of IDataPointProvider to avoid the need for mapping by reflection.