### PR TITLE
Using ExportToBitmap to get a bitmap

### DIFF
--- a/export/export-png.rst
+++ b/export/export-png.rst
@@ -26,8 +26,7 @@ Copy to clipboard
 
     using (var stream = new MemoryStream())
     {
-        var exporter = new OxyPlot.Wpf.PngExporter();
-        var bitmap =  exporter.ExportToBitmap(Model);
-
-        Clipboard.SetImage(bitmap);
+        var bitmap = OxyPlot.Wpf.PngExporter.ExportToBitmap(
+					Model, (int)Model.Width, (int)Model.Height, OxyColors.White);
+		Clipboard.SetImage(bitmap);
     }

--- a/export/export-png.rst
+++ b/export/export-png.rst
@@ -26,15 +26,8 @@ Copy to clipboard
 
     using (var stream = new MemoryStream())
     {
-        var pngExporter = new PngExporter();
-        pngExporter.Export(plotModel, stream, 600, 400, Brushes.White);
-        
-        var bitmap = new BitmapImage();
-        bitmap.BeginInit();
-        bitmap.StreamSource = stream;
-        bitmap.CacheOption = BitmapCacheOption.OnLoad;
-        bitmap.EndInit();
-        bitmap.Freeze();
-            
+        var exporter = new OxyPlot.Wpf.PngExporter();
+        var bitmap =  exporter.ExportToBitmap(Model);
+
         Clipboard.SetImage(bitmap);
     }


### PR DESCRIPTION
PngExporter has a method to export directly to a bitmap, so I don't need to convert it afterwards.