### PR TITLE
Add DateTimeAxis label example

### DIFF
--- a/models/axes/DateTimeAxis.rst
+++ b/models/axes/DateTimeAxis.rst
@@ -46,5 +46,11 @@ Example
 .. code:: csharp
 
     var model = new PlotModel { Title = "DateTimeAxis" };
-    model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = -20, Maximum = 80});
-    model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Minimum = -10, Maximum = 10});
+    
+    var startDate = DateTime.Now.AddDays(-10);
+    var endDate = DateTime.Now;
+    
+    var minValue = DateTimeAxis.ToDouble(startDate);
+    var maxValue = DateTimeAxis.ToDouble(endDate);
+    
+    model.Axes.Add(new DateTimeAxis { Position = AxisPosition.Bottom, Minimum = minValue, Maximum = maxValue, StringFormat = "M/d"});


### PR DESCRIPTION
I thought the example for DateTimeAxis was too sparse, it was difficult to understand where/how to specify the start/end date and how to format the labels. I also fixed a typo where a LinearAxis was added to the PlotModel, not a DateTimeAxis. 

This example should make it easier for users to visualize how to get from two DateTimes to the range of labels that they want on the axis they provide.